### PR TITLE
Daily post-it widget + popup-dismissal rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,32 @@ Not required on:
 
 ---
 
+## Popup-dismissal rule
+
+Every dismissable alert/banner/popup must persist its dismissal **keyed to the unique trigger that caused it**, so dismissing it once does not silence it forever — a *new* trigger reappears the alert.
+
+**The rule:**
+1. **Never use a plain `useState(false)` boolean for "dismissed".** It loses state on refresh, and conflates "I've seen this trigger" with "I never want to see this again."
+2. Pick a stable id from whatever caused the alert:
+   - Email-driven alert (payroll, finance, CC allocation) → `email.id` or `messageId`
+   - Calendar-driven alert (board prep, meeting prep) → calendar event `id` (fallback to `start` time)
+   - Content-driven recurring alert (birthday) → a **content hash** of the trigger payload (e.g., names+dates joined). Persists across midnight; only resets when the underlying content changes (new person, next year's birthday).
+   - Truly per-day reminders (e.g., "today's planning prompt") → today's `localDateKey()`. **Do not use this for time-sensitive alerts the user might miss.**
+3. Persist to `localStorage` as `ffc_dismissed_<feature>` (single id) or `ffc_dismissed_<feature>` JSON array (multiple).
+4. Render condition: `triggerActive && currentTriggerId !== dismissedId` (or `!dismissedSet.has(currentTriggerId)`).
+5. **Every dismissal must show an Undo toast.** Use `showToast(msg, onUndo)` with an `onUndo` callback that reverses the dismissal (sets the persisted id back to its previous value, or removes from the Set). The user can fat-finger the X — the alert should not be lost without recourse.
+
+**Reference implementations in `index.js`:**
+- Single-id (email): `dismissedCcAllocId` / `ffc_dismissed_cc_alloc`
+- Single-id (event): `dismissedBoardPrepId` / `ffc_dismissed_board_prep`
+- Single-id (content hash): `dismissedBirthdayKey` / `ffc_dismissed_birthday` — uses `birthdayContentKey(birthdays)` so dismissal sticks until the birthday set changes
+- Set: `dismissedPayrollIds` / `ffc_dismissed_payroll` (with `undoDismissPayroll`)
+- Set: `dismissedFinanceIds` / `ffc_dismissed_finance` (with `undoDismissFinance`)
+
+If you add a new alert and use a plain boolean, or skip the undo toast, the review subagent should flag it.
+
+---
+
 ## Email reply behavior
 
 **Reply-all is always the default.** When composing a reply (in `ComposeForm` or any automated send like payroll approval), always include the original To and CC recipients in the outgoing CC. Never default to reply-to-sender-only.

--- a/src/__tests__/dailySticky.test.js
+++ b/src/__tests__/dailySticky.test.js
@@ -1,0 +1,72 @@
+const { localDateKey, dailyStickyKey, loadDailySticky, saveDailySticky } = require('../lib/dailySticky');
+
+describe('dailySticky', () => {
+  describe('localDateKey', () => {
+    test('formats date as YYYY-MM-DD', () => {
+      expect(localDateKey(new Date(2026, 4, 5))).toBe('2026-05-05');
+    });
+    test('zero-pads single-digit months and days', () => {
+      expect(localDateKey(new Date(2026, 0, 9))).toBe('2026-01-09');
+    });
+    test('uses current date when called with no arg', () => {
+      const k = localDateKey();
+      expect(k).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('dailyStickyKey', () => {
+    test('prefixes with ffc_daily_sticky_', () => {
+      expect(dailyStickyKey(new Date(2026, 4, 5))).toBe('ffc_daily_sticky_2026-05-05');
+    });
+    test('produces different keys for different days', () => {
+      const a = dailyStickyKey(new Date(2026, 4, 5));
+      const b = dailyStickyKey(new Date(2026, 4, 6));
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('loadDailySticky / saveDailySticky', () => {
+    function makeStorage() {
+      const data = {};
+      return {
+        getItem: k => (k in data ? data[k] : null),
+        setItem: (k, v) => { data[k] = String(v); },
+        _data: data,
+      };
+    }
+
+    test('round-trips text for a given date', () => {
+      const s = makeStorage();
+      const d = new Date(2026, 4, 5);
+      saveDailySticky(s, d, 'milk\neggs\ncall Pat');
+      expect(loadDailySticky(s, d)).toBe('milk\neggs\ncall Pat');
+    });
+
+    test('returns empty string when nothing stored for that date', () => {
+      const s = makeStorage();
+      expect(loadDailySticky(s, new Date(2026, 4, 5))).toBe('');
+    });
+
+    test('isolates content between days', () => {
+      const s = makeStorage();
+      saveDailySticky(s, new Date(2026, 4, 5), 'monday list');
+      saveDailySticky(s, new Date(2026, 4, 6), 'tuesday list');
+      expect(loadDailySticky(s, new Date(2026, 4, 5))).toBe('monday list');
+      expect(loadDailySticky(s, new Date(2026, 4, 6))).toBe('tuesday list');
+    });
+
+    test('handles null storage gracefully (SSR)', () => {
+      expect(loadDailySticky(null, new Date())).toBe('');
+      expect(() => saveDailySticky(null, new Date(), 'x')).not.toThrow();
+    });
+
+    test('swallows storage exceptions (quota / disabled)', () => {
+      const broken = {
+        getItem: () => { throw new Error('blocked'); },
+        setItem: () => { throw new Error('quota'); },
+      };
+      expect(loadDailySticky(broken, new Date())).toBe('');
+      expect(() => saveDailySticky(broken, new Date(), 'x')).not.toThrow();
+    });
+  });
+});

--- a/src/lib/dailySticky.js
+++ b/src/lib/dailySticky.js
@@ -1,0 +1,25 @@
+// Daily post-it sticky note — keyed per local-date so each day starts fresh.
+// Prior days' content stays in localStorage (not auto-deleted) but is not surfaced.
+
+function pad2(n) { return n < 10 ? '0' + n : '' + n; }
+
+function localDateKey(date) {
+  const d = date instanceof Date ? date : new Date();
+  return d.getFullYear() + '-' + pad2(d.getMonth() + 1) + '-' + pad2(d.getDate());
+}
+
+function dailyStickyKey(date) {
+  return 'ffc_daily_sticky_' + localDateKey(date);
+}
+
+function loadDailySticky(storage, date) {
+  if (!storage) return '';
+  try { return storage.getItem(dailyStickyKey(date)) || ''; } catch { return ''; }
+}
+
+function saveDailySticky(storage, date, text) {
+  if (!storage) return;
+  try { storage.setItem(dailyStickyKey(date), text); } catch {}
+}
+
+module.exports = { localDateKey, dailyStickyKey, loadDailySticky, saveDailySticky };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import Head from "next/head";
 import MeetingPrepDrawer from "../components/MeetingPrepDrawer";
+import { localDateKey, loadDailySticky, saveDailySticky } from "../lib/dailySticky";
 
 // ═══════════════════════════════════════════════
 //  THEME
@@ -2810,6 +2811,26 @@ export default function Home() {
     return [];
   });
   const [newStickyText, setNewStickyText] = useState("");
+  const [dailyStickyOpen, setDailyStickyOpen] = useState(false);
+  const [dailyStickyDate, setDailyStickyDate] = useState(() => localDateKey());
+  const [dailyStickyText, setDailyStickyText] = useState("");
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setDailyStickyText(loadDailySticky(window.localStorage, new Date()));
+    const tick = () => {
+      const k = localDateKey();
+      if (k !== dailyStickyDate) {
+        setDailyStickyDate(k);
+        setDailyStickyText(loadDailySticky(window.localStorage, new Date()));
+      }
+    };
+    const id = setInterval(tick, 60_000);
+    return () => clearInterval(id);
+  }, [dailyStickyDate]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    saveDailySticky(window.localStorage, new Date(), dailyStickyText);
+  }, [dailyStickyText, dailyStickyDate]);
   const [voiceListening, setVoiceListening] = useState(false);
   const voiceRecognitionRef = useRef(null);
   const [editingCaptureId, setEditingCaptureId] = useState(null);
@@ -2840,6 +2861,11 @@ export default function Home() {
     try { localStorage.setItem('ffc_dismissed_payroll', JSON.stringify([...next])); } catch {}
     return next;
   });
+  const undoDismissPayroll = id => setDismissedPayrollIds(prev => {
+    const next = new Set(prev); next.delete(id);
+    try { localStorage.setItem('ffc_dismissed_payroll', JSON.stringify([...next])); } catch {}
+    return next;
+  });
 
   const [dismissedFinanceIds, setDismissedFinanceIds] = useState(new Set());
   useEffect(() => {
@@ -2853,12 +2879,40 @@ export default function Home() {
     try { localStorage.setItem('ffc_dismissed_finance', JSON.stringify([...next])); } catch {}
     return next;
   });
+  const undoDismissFinance = id => setDismissedFinanceIds(prev => {
+    const next = new Set(prev); next.delete(id);
+    try { localStorage.setItem('ffc_dismissed_finance', JSON.stringify([...next])); } catch {}
+    return next;
+  });
 
-  const [boardPrepDismissed, setBoardPrepDismissed] = useState(false);
-  const [birthdayDismissed, setBirthdayDismissed] = useState(false);
+  // Popup-dismissal rule: every dismissable alert persists the trigger id so the alert reappears ONLY when the underlying trigger changes. See CLAUDE.md "Popup-dismissal rule".
+  const [dismissedBoardPrepId, setDismissedBoardPrepId] = useState(null);
+  const [dismissedBirthdayKey, setDismissedBirthdayKey] = useState(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try { setDismissedBoardPrepId(localStorage.getItem("ffc_dismissed_board_prep")); } catch {}
+    try { setDismissedBirthdayKey(localStorage.getItem("ffc_dismissed_birthday")); } catch {}
+  }, []);
+  const dismissBoardPrep = id => {
+    setDismissedBoardPrepId(id);
+    try { if (id) localStorage.setItem("ffc_dismissed_board_prep", id); } catch {}
+  };
+  const dismissBirthday = key => {
+    setDismissedBirthdayKey(key);
+    try { if (key) localStorage.setItem("ffc_dismissed_birthday", key); } catch {}
+  };
+  const birthdayContentKey = bs => (bs || []).map(b => `${b.name || ''}_${b.date || ''}`).join('|');
   const [ccAllocInfo, setCcAllocInfo] = useState(null); // { found, messageId, threadId, subject, spreadsheetUrl, ... }
   const [ccAllocPanel, setCcAllocPanel] = useState(false);
-  const [ccAllocDismissed, setCcAllocDismissed] = useState(false);
+  const [dismissedCcAllocId, setDismissedCcAllocId] = useState(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try { setDismissedCcAllocId(localStorage.getItem("ffc_dismissed_cc_alloc")); } catch {}
+  }, []);
+  const dismissCcAlloc = id => {
+    setDismissedCcAllocId(id);
+    try { if (id) localStorage.setItem("ffc_dismissed_cc_alloc", id); } catch {}
+  };
   const [aiPrep, setAiPrep] = useState({}); // eventId → { loading, text, error }
   const [aiFocus, setAiFocus] = useState(null); // { loading, items, error }
   const [aiTriage, setAiTriage] = useState(null); // { loading, recommendations: [{id, action, reason}] }
@@ -4038,13 +4092,13 @@ export default function Home() {
             </div>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               <div onClick={() => setPayrollPanel(e)} style={{ padding: "10px 24px", background: "#fff", color: "#D45555", borderRadius: 8, fontWeight: 800, fontSize: 15, whiteSpace: "nowrap", cursor: "pointer" }}>Run Payroll Review →</div>
-              <button onClick={ev => { ev.stopPropagation(); dismissPayroll(e.id); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
+              <button onClick={ev => { ev.stopPropagation(); dismissPayroll(e.id); showToast("Payroll alert dismissed", () => undoDismissPayroll(e.id)); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
             </div>
           </div>
         ))}
 
         {/* Board prep — sticky alert when board meeting is within 21 days */}
-        {boardPrepInfo?.meeting && !boardPrepPanel && !boardPrepDismissed && (
+        {boardPrepInfo?.meeting && !boardPrepPanel && (boardPrepInfo.meeting.id || boardPrepInfo.meeting.start) !== dismissedBoardPrepId && (
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, padding: "14px 22px", background: T.emailBlue, borderRadius: 12, marginBottom: 12, cursor: "pointer", boxShadow: "0 4px 20px rgba(59,130,196,0.35)" }} onClick={() => setBoardPrepPanel(true)}>
             <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
               <span style={{ fontSize: 26 }}>📋</span>
@@ -4055,7 +4109,7 @@ export default function Home() {
             </div>
             <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
               <div style={{ padding: "10px 24px", background: "#fff", color: T.emailBlue, borderRadius: 8, fontWeight: 800, fontSize: 15, whiteSpace: "nowrap" }}>Start Prep →</div>
-              <button onClick={e => { e.stopPropagation(); setBoardPrepDismissed(true); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
+              <button onClick={e => { e.stopPropagation(); const id = boardPrepInfo.meeting.id || boardPrepInfo.meeting.start; const prev = dismissedBoardPrepId; dismissBoardPrep(id); showToast("Board prep alert dismissed", () => dismissBoardPrep(prev)); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
             </div>
           </div>
         )}
@@ -4066,7 +4120,7 @@ export default function Home() {
         )}
 
         {/* Credit Card Allocation alert */}
-        {ccAllocInfo?.found && !ccAllocPanel && !ccAllocDismissed && (
+        {ccAllocInfo?.found && !ccAllocPanel && ccAllocInfo.messageId !== dismissedCcAllocId && (
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, padding: "14px 22px", background: T.taskAmber, borderRadius: 12, marginBottom: 12, cursor: "pointer", boxShadow: "0 4px 20px rgba(196,148,42,0.35)" }} onClick={() => setCcAllocPanel(true)}>
             <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
               <span style={{ fontSize: 26 }}>💳</span>
@@ -4077,7 +4131,7 @@ export default function Home() {
             </div>
             <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
               <div style={{ padding: "10px 24px", background: "#fff", color: T.taskAmber, borderRadius: 8, fontWeight: 800, fontSize: 15, whiteSpace: "nowrap" }}>Start Flow →</div>
-              <button onClick={e => { e.stopPropagation(); setCcAllocDismissed(true); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
+              <button onClick={e => { e.stopPropagation(); const id = ccAllocInfo.messageId; const prev = dismissedCcAllocId; dismissCcAlloc(id); showToast("Credit card alert dismissed", () => dismissCcAlloc(prev)); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
             </div>
           </div>
         )}
@@ -4088,7 +4142,7 @@ export default function Home() {
         )}
 
         {/* Birthday alert */}
-        {birthdayInfo?.birthdays?.length > 0 && !birthdayPanel && !birthdayDismissed && (
+        {birthdayInfo?.birthdays?.length > 0 && !birthdayPanel && birthdayContentKey(birthdayInfo.birthdays) !== dismissedBirthdayKey && (
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, padding: "14px 22px", background: T.gold, borderRadius: 12, marginBottom: 12, cursor: "pointer", boxShadow: `0 4px 20px rgba(196,148,42,0.4)` }} onClick={() => setBirthdayPanel(true)}>
             <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
               <span style={{ fontSize: 26 }}>🎂</span>
@@ -4103,7 +4157,7 @@ export default function Home() {
             </div>
             <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
               <div style={{ padding: "10px 24px", background: "#fff", color: T.gold, borderRadius: 8, fontWeight: 800, fontSize: 15, whiteSpace: "nowrap" }}>Draft Message →</div>
-              <button onClick={e => { e.stopPropagation(); setBirthdayDismissed(true); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
+              <button onClick={e => { e.stopPropagation(); const k = birthdayContentKey(birthdayInfo.birthdays); const prev = dismissedBirthdayKey; dismissBirthday(k); showToast("Birthday dismissed", () => dismissBirthday(prev)); }} style={{ background: "rgba(255,255,255,0.25)", border: "none", borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: "#fff", fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }} title="Dismiss">×</button>
             </div>
           </div>
         )}
@@ -4374,7 +4428,7 @@ export default function Home() {
                   <button onClick={() => setFinancePanel(debbieDetailsEmail)} style={{ padding: "10px 22px", background: T.taskAmber, color: "#fff", border: "none", borderRadius: 8, fontWeight: 600, fontSize: 15, cursor: "pointer" }}>
                     Run Finance Review →
                   </button>
-                  <button onClick={e => { e.stopPropagation(); dismissFinance(debbieDetailsEmail.id); }} style={{ background: "none", border: `1px solid ${T.taskAmberBorder}`, borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: T.taskAmber, fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center" }} title="Dismiss">×</button>
+                  <button onClick={e => { e.stopPropagation(); const id = debbieDetailsEmail.id; dismissFinance(id); showToast("Finance alert dismissed", () => undoDismissFinance(id)); }} style={{ background: "none", border: `1px solid ${T.taskAmberBorder}`, borderRadius: "50%", width: 30, height: 30, cursor: "pointer", color: T.taskAmber, fontSize: 18, display: "flex", alignItems: "center", justifyContent: "center" }} title="Dismiss">×</button>
                 </div>
               </div>
             )}
@@ -6449,6 +6503,31 @@ export default function Home() {
 
       {expandedEmail && (
         <div onClick={() => setExpandedEmail(null)} style={{ position: "fixed", inset: 0, zIndex: 1, cursor: "default" }} />
+      )}
+
+      {/* Daily post-it — per-day scratchpad, bottom-left floating */}
+      {!dailyStickyOpen && (
+        <button onClick={() => setDailyStickyOpen(true)} title="Today's notes"
+          style={{ position: "fixed", bottom: 28, left: 28, width: 52, height: 52, borderRadius: "50%", background: T.stickyYellowBg, border: `2px solid ${T.stickyYellowBorder}`, cursor: "pointer", fontSize: 24, display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 4px 16px rgba(0,0,0,0.2)", zIndex: 999 }}>
+          📝
+        </button>
+      )}
+      {dailyStickyOpen && (
+        <>
+          <div onClick={() => setDailyStickyOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 999 }} />
+          <div style={{ position: "fixed", bottom: 28, left: 28, width: 320, height: 380, background: T.stickyYellowBg, border: `2px solid ${T.stickyYellowBorder}`, borderRadius: 12, boxShadow: "0 8px 32px rgba(0,0,0,0.25)", zIndex: 1000, display: "flex", flexDirection: "column", padding: 16, transform: "rotate(-1deg)" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: T.text, letterSpacing: "0.04em", textTransform: "uppercase" }}>
+                {new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })}
+              </div>
+              <button onClick={() => setDailyStickyOpen(false)} title="Close"
+                style={{ background: "transparent", border: "none", cursor: "pointer", fontSize: 20, color: T.text, lineHeight: 1, padding: 0, width: 24, height: 24 }}>×</button>
+            </div>
+            <textarea autoFocus value={dailyStickyText} onChange={e => setDailyStickyText(e.target.value)}
+              placeholder="Today's items..."
+              style={{ flex: 1, width: "100%", border: "none", background: "transparent", color: T.text, fontSize: 15, fontFamily: "inherit", resize: "none", outline: "none", lineHeight: 1.5, boxSizing: "border-box" }} />
+          </div>
+        </>
       )}
 
       <LightbulbFAB />


### PR DESCRIPTION
## Summary
- **Daily post-it widget** — floating 📝 button (bottom-left) opens a tilted yellow sticky scoped per local-date. Auto-saves on every keystroke; midnight rollover handled. Prior days preserved in localStorage.
- **Fix: CC allocation banner reappearing after dismissal** — was a plain `useState(false)` that lost state on refresh. Now persisted by `messageId`, so it only reappears when Debbie sends a *new* allocation email.
- **Same fix applied to board prep & birthday banners** — both had the identical plain-boolean bug. Board prep is now keyed by event `id`; birthday is keyed by a content-hash of names+dates so it does **not** disappear at midnight (Kayla's specific concern — she might miss it).
- **Undo toast on every popup dismissal** — payroll, finance, CC alloc, board prep, birthday. Uses existing `showToast(msg, onUndo)`. Prevents accidentally losing the alert with a stray X click.
- **CLAUDE.md** — new "Popup-dismissal rule" section codifying the pattern (no boolean dismissals; key by trigger id or content-hash; undo toast required). Review subagent should flag violations.

## Files
- `src/lib/dailySticky.js` (new) — per-day storage helpers
- `src/__tests__/dailySticky.test.js` (new) — 10 passing tests
- `src/pages/index.js` — widget + dismissal refactors
- `CLAUDE.md` — new rule section

## Test plan
- [x] `jest src/__tests__/dailySticky.test.js` — 10/10 pass
- [x] `next build` — clean
- [ ] Manual: open dashboard, click 📝, type, refresh — content persists
- [ ] Manual: dismiss CC alloc, refresh — stays dismissed; click Undo in toast — reappears
- [ ] Manual: dismiss birthday, wait past midnight (or change system clock) — stays dismissed
- [ ] Manual: every X click shows an "... dismissed" toast with Undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)